### PR TITLE
SublimeLinter 4 Compatibility

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -10,7 +10,7 @@
 
 """This module exports the Codeclimate plugin class."""
 
-from SublimeLinter.lint import Linter, util, persist
+from SublimeLinter.lint import Linter, util
 
 
 class Codeclimate(Linter):
@@ -51,5 +51,4 @@ class Codeclimate(Linter):
         if relative_file_name == None:
             return result
         result.append(relative_file_name)
-        # persist.debug(result)
         return result

--- a/linter.py
+++ b/linter.py
@@ -51,5 +51,5 @@ class Codeclimate(Linter):
         if relative_file_name == None:
             return result
         result.append(relative_file_name)
-        persist.debug(result)
+        # persist.debug(result)
         return result

--- a/linter.py
+++ b/linter.py
@@ -17,42 +17,38 @@ class Codeclimate(Linter):
     """Provides an interface to codeclimate."""
 
     defaults = {
+        'chdir': "${project}",
+        'executable': 'codeclimate',
         'selector': (
-            'source.css - '
-            'source.go - '
-            'source.haskall - '
-            'source.java - '
-            'source.javascript - '
-            'source.php - '
-            'source.python - '
-            'source.ruby - '
-            'source.scss - '
-            'source.shell - '
+            'source.css, '
+            'source.go, '
+            'source.haskall, '
+            'source.java, '
+            'source.javascript, '
+            'source.php, '
+            'source.python, '
+            'source.ruby, '
+            'source.scss, '
+            'source.shell, '
             'text.html'
         )
     }
-    executable = "codeclimate"
     regex = r'^(?P<line>\d+)(?:-\d+)?:\s(?P<message>.+)$'
     multiline = False
     line_col_base = (1, 1)
     tempfile_suffix = '-'
     error_stream = util.STREAM_BOTH
-    selectors = {}
     word_re = None
-    defaults = {
-        'chdir': "${project}"
-    }
-    inline_settings = None
-    inline_overrides = None
-    comment_re = None
 
     def cmd(self):
         """Construct a cmd to provide a relative path to 'codeclimate analyze'."""
-        result = [self.executable_path, 'analyze']
+        result = ['codeclimate', 'analyze']
         relative_file_name = None
         for folder in self.view.window().folders():
             if self.filename.find(folder) == 0:
                 relative_file_name = self.filename.replace(folder + '/', '')
+        if relative_file_name == None:
+            return result
         result.append(relative_file_name)
         persist.debug(result)
         return result

--- a/linter.py
+++ b/linter.py
@@ -42,7 +42,7 @@ class Codeclimate(Linter):
 
     def cmd(self):
         """Construct a cmd to provide a relative path to 'codeclimate analyze'."""
-        result = ['codeclimate', 'analyze', '-e structure', '-e duplication']
+        result = ['codeclimate', 'analyze', '-e', 'structure', '-e', 'duplication']
         relative_file_name = None
         for folder in self.view.window().folders():
             if self.filename.find(folder) == 0:

--- a/linter.py
+++ b/linter.py
@@ -42,7 +42,7 @@ class Codeclimate(Linter):
 
     def cmd(self):
         """Construct a cmd to provide a relative path to 'codeclimate analyze'."""
-        result = ['codeclimate', 'analyze']
+        result = ['codeclimate', 'analyze', '-e structure', '-e duplication']
         relative_file_name = None
         for folder in self.view.window().folders():
             if self.filename.find(folder) == 0:

--- a/linter.py
+++ b/linter.py
@@ -25,6 +25,7 @@ class Codeclimate(Linter):
             'source.haskall, '
             'source.java, '
             'source.javascript, '
+            'source.js, '
             'source.php, '
             'source.python, '
             'source.ruby, '

--- a/linter.py
+++ b/linter.py
@@ -16,20 +16,21 @@ from SublimeLinter.lint import Linter, util, persist
 class Codeclimate(Linter):
     """Provides an interface to codeclimate."""
 
-    syntax = (
-        'ruby on rails',
-        'ruby',
-        'javascript',
-        'python',
-        'go',
-        'html',
-        'css',
-        'markdown',
-        'php',
-        'haskall',
-        'java',
-        'shellscript'
-    )
+    defaults = {
+        'selector': (
+            'source.css - '
+            'source.go - '
+            'source.haskall - '
+            'source.java - '
+            'source.javascript - '
+            'source.php - '
+            'source.python - '
+            'source.ruby - '
+            'source.scss - '
+            'source.shell - '
+            'text.html'
+        )
+    }
     executable = "codeclimate"
     regex = r'^(?P<line>\d+)(?:-\d+)?:\s(?P<message>.+)$'
     multiline = False


### PR DESCRIPTION
As requested by @meengit, I'm placing a PR here for review.

In addition to fixing it up for SublimeLinter 4, I made the codeclimate CLI only run `structure` and `duplication` engines since there are much better linters out there for all of the other engines (i.e. Rubocop) and I don't need the double messages.